### PR TITLE
Restructured string loading

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -10,5 +10,6 @@
         "servers": [
             "matrix.org"
         ]
-    }
+    },
+    "languages": ["en", "de", "pt-br", "ru", "da"]
 }

--- a/scripts/copy-res.js
+++ b/scripts/copy-res.js
@@ -153,13 +153,13 @@ fs.readdir(testFolder, function(err, files) {
     throw err;
   }
   files.forEach(function(file) {
-    if (file.indexOf("-") > -1) {
-      languages[file.split('-')[0]] = file;
-    } else if (file.indexOf("_") > -1) {
-      languages[file.split('_')[0]] = file;
-    } else {
-      languages[file.split('.json')[0]] = file;
-    }
+  	var normalizedLanguage = file.toLowerCase().replace("_","-").split('.json')[0];
+  	var languageParts = normalizedLanguage.split('-');
+	if (languageParts.length==2 && languageParts[0]==languageParts[1]) {
+		languages[languageParts[0]] = file;
+	} else {
+		languages[normalizedLanguage] = file;
+	}
   });
   fs.writeFile('webapp/i18n/languages.json', JSON.stringify(languages, null, 4));
 })

--- a/src/components/structures/RoomDirectory.js
+++ b/src/components/structures/RoomDirectory.js
@@ -533,7 +533,7 @@ module.exports = React.createClass({
 
         let placeholder = counterpart.translate('Search for a room');
         if (!this.state.instanceId) {
-            placeholder = counterpart.translate('#example:') + this.state.roomServer;
+            placeholder = counterpart.translate('#example') + ":" + this.state.roomServer;
         } else if (instance_expected_field_type) {
             placeholder = instance_expected_field_type.placeholder;
         }


### PR DESCRIPTION
1. Now languages are in config.json (in riot-web), and not in dropdown element anymore
2. Now there is an unifying way to treat language keys. In riot and matrix-react-sdk, they will be always low case and with hyphen. If file is en_EN.json, it will be "en", since it's two times the same letter. But if it's en_AU or pt_BR, it will be en-au and pt-br.
3. Now there is a new module called "languageHandler", which loads only once the language data and already sets counterpart for both matrix-react-sdk and riot-web